### PR TITLE
Use the registered layoutAttributesClass

### DIFF
--- a/RFQuiltLayout/RFQuiltLayout.m
+++ b/RFQuiltLayout/RFQuiltLayout.m
@@ -103,7 +103,7 @@
     
     
     CGRect frame = [self frameForIndexPath:indexPath];
-    UICollectionViewLayoutAttributes* attributes = [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];
+    UICollectionViewLayoutAttributes* attributes = [self.class.layoutAttributesClass layoutAttributesForCellWithIndexPath:indexPath];
     attributes.frame = UIEdgeInsetsInsetRect(frame, insets);
     return attributes;
 }


### PR DESCRIPTION
`UICollectionViewLayoutAttributes` should not be hardwired because a subclass could have registered a different `layoutAttributesClass`. If not it defaults to `UICollectionViewLayoutAttributes` anyway.
